### PR TITLE
Code review cleanup: test fixture + remove dead code

### DIFF
--- a/SampleDrumConverter/ContentView.swift
+++ b/SampleDrumConverter/ContentView.swift
@@ -4,9 +4,6 @@ import UniformTypeIdentifiers
 // MARK: - Constants
 enum AppConstants {
     static let bufferSize: UInt32 = 32768
-    static let githubRepository = "JarlLyng/It-s-mono-yo-"
-    static let githubReleasesURL = "https://api.github.com/repos/\(githubRepository)/releases/latest"
-    static let githubReleasesPageURL = "https://github.com/\(githubRepository)/releases/latest"
     static let defaultAppVersion = "1.3.0"
 }
 
@@ -124,11 +121,6 @@ struct ContentView: View {
             return "\(failed) files failed to convert"
         }
         return "All files converted successfully"
-    }
-    
-    var totalFileSize: Int64 {
-        audioFiles.compactMap { try? FileManager.default.attributesOfItem(atPath: $0.url.path)[.size] as? Int64 }
-            .reduce(0, +)
     }
     
     var body: some View {
@@ -266,21 +258,6 @@ struct ContentView: View {
         }
     }
 
-    private func formatFileSize(_ size: Int64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useMB, .useKB]
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: size)
-    }
-
-    private func removeFiles(at offsets: IndexSet) {
-        audioFiles.remove(atOffsets: offsets)
-    }
-
-    private func clearFiles() {
-        audioFiles.removeAll()
-    }
-
     func selectFiles() {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.wav, .aiff]
@@ -295,39 +272,6 @@ struct ContentView: View {
         }
     }
     
-    func selectOutputFolder() {
-        let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = false
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.canCreateDirectories = true
-        panel.prompt = "Choose Output Folder"
-        
-        if panel.runModal() == .OK {
-            outputFolder = panel.url
-            setStatusMessage("Output folder selected: \(panel.url?.lastPathComponent ?? "")")
-        }
-    }
-    
-    
-
-    @MainActor
-    private func addFile(from url: URL) {
-        let newFile = AudioFile(url: url, format: getAudioFormat(for: url))
-        audioFiles.append(newFile)
-    }
-
-    /// Logs a debug message with timestamp
-    /// - Parameter message: The message to log
-    /// - Note: Only logs in DEBUG builds
-    private func log(_ message: String) {
-        #if DEBUG
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        print("[\(formatter.string(from: Date()))] \(message)")
-        #endif
-    }
-
     /// Shows user where to get updates (App Store). No network access – app uses minimal entitlements for App Review.
     private func checkForUpdates() {
         latestVersion = ""
@@ -335,25 +279,6 @@ struct ContentView: View {
         showingUpdateAlert = true
     }
     
-    /// Compares two semantic version strings
-    /// - Returns: > 0 if v1 > v2, < 0 if v1 < v2, 0 if equal
-    private func compareVersions(_ v1: String, _ v2: String) -> Int {
-        let parts1 = v1.split(separator: ".").compactMap { Int($0) }
-        let parts2 = v2.split(separator: ".").compactMap { Int($0) }
-        
-        let maxCount = max(parts1.count, parts2.count)
-        
-        for i in 0..<maxCount {
-            let p1 = i < parts1.count ? parts1[i] : 0
-            let p2 = i < parts2.count ? parts2[i] : 0
-            
-            if p1 > p2 { return 1 }
-            if p1 < p2 { return -1 }
-        }
-        
-        return 0
-    }
-
     /// Updates the status message shown to the user
     /// - Parameter message: The message to display
     /// - Note: Message will be cleared when state changes (e.g., conversion starts/stops)
@@ -408,8 +333,6 @@ private struct UpdateAlertModifier: ViewModifier {
 struct FileRowView: View {
     let file: AudioFile
     let onRemove: () -> Void
-    var onRetry: (() -> Void)?
-    var onReveal: (() -> Void)?
     @State private var isHovering = false
     @Environment(\.colorScheme) private var colorScheme
     
@@ -448,17 +371,6 @@ struct FileRowView: View {
         }
         .adaptiveAnimation(.easeInOut(duration: 0.2), value: isHovering)
         .contextMenu {
-            if file.status == .failed {
-                Button(action: { onRetry?() }) {
-                    Label("Retry Conversion", systemImage: "arrow.clockwise")
-                }
-            }
-            if file.status == .completed {
-                Button(action: { onReveal?() }) {
-                    Label("Show in Finder", systemImage: "folder")
-                }
-            }
-            Divider()
             if #available(macOS 12.0, *) {
                 Button(role: .destructive, action: { onRemove() }) {
                     Label("Remove", systemImage: "trash")
@@ -1135,14 +1047,6 @@ struct CompletionView: View {
                 ReviewPrompt.recordSuccessfulConversion()
             }
         }
-    }
-}
-
-struct GitHubRelease: Codable {
-    let tagName: String
-    
-    enum CodingKeys: String, CodingKey {
-        case tagName = "tag_name"
     }
 }
 

--- a/SampleDrumConverterTests/AudioConversionTests.swift
+++ b/SampleDrumConverterTests/AudioConversionTests.swift
@@ -3,30 +3,93 @@ import AVFoundation
 @testable import It_s_mono__yo_
 
 final class AudioConversionTests: XCTestCase {
-    let testBundle = Bundle(for: AudioConversionTests.self)
+
+    /// Stereo test fixture generated fresh for each test in `setUp`.
+    /// Generating it programmatically keeps a binary blob out of git and
+    /// guarantees the conversion tests actually run (instead of XCTSkip).
+    private var stereoFixtureURL: URL!
+
+    override func setUpWithError() throws {
+        stereoFixtureURL = try Self.makeStereoFixture()
+    }
+
+    override func tearDownWithError() throws {
+        if let url = stereoFixtureURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        stereoFixtureURL = nil
+    }
+
+    // MARK: - Fixture Generation
+
+    /// Writes a short 2-channel, 44.1 kHz WAV file where the left channel is a
+    /// constant +0.5 and the right channel a constant -0.5. After an equal-weight
+    /// stereo downmix the mono result is 0.0, which gives the conversion tests a
+    /// deterministic value to assert against.
+    private static func makeStereoFixture() throws -> URL {
+        let sampleRate = 44_100.0
+        let frameCount: AVAudioFrameCount = 4_410 // 0.1s
+
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 2,
+            interleaved: false
+        ), let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw XCTSkip("Could not allocate test audio buffer")
+        }
+
+        buffer.frameLength = frameCount
+        let channels = buffer.floatChannelData!
+        for frame in 0..<Int(frameCount) {
+            channels[0][frame] = 0.5  // left
+            channels[1][frame] = -0.5 // right
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_stereo_\(UUID().uuidString).wav")
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        try file.write(from: buffer)
+        return url
+    }
 
     // MARK: - Basic Conversion
 
     func testStereoToMonoConversion() async throws {
-        guard let inputURL = testBundle.url(forResource: "test_stereo", withExtension: "wav") else {
-            throw XCTSkip("Test fixture 'test_stereo.wav' not found in test bundle")
-        }
-
         let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_output.wav")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         // Default settings: 16-bit WAV
-        try await convertAudioFile(inputURL: inputURL, outputURL: outputURL, settings: OutputSettings()) { _ in }
+        try await convertAudioFile(inputURL: stereoFixtureURL, outputURL: outputURL, settings: OutputSettings()) { _ in }
 
-        guard let outputFile = try? AVAudioFile(forReading: outputURL) else {
-            XCTFail("Could not read output file")
-            return
-        }
-
+        let outputFile = try XCTUnwrap(try? AVAudioFile(forReading: outputURL))
         XCTAssertEqual(outputFile.processingFormat.channelCount, 1)
 
-        let inputFile = try XCTUnwrap(try? AVAudioFile(forReading: inputURL))
+        let inputFile = try XCTUnwrap(try? AVAudioFile(forReading: stereoFixtureURL))
         XCTAssertEqual(outputFile.processingFormat.sampleRate, inputFile.processingFormat.sampleRate)
+    }
+
+    /// Verifies the downmix math, not just the channel count: equal-weight summing
+    /// of L=+0.5 and R=-0.5 must produce silence (0.0) in the mono output.
+    func testDownmixSumsChannelsCorrectly() async throws {
+        let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_downmix.wav")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        var settings = OutputSettings()
+        settings.bitDepth = .float32
+        try await convertAudioFile(inputURL: stereoFixtureURL, outputURL: outputURL, settings: settings) { _ in }
+
+        let outputFile = try XCTUnwrap(try? AVAudioFile(forReading: outputURL))
+        let format = outputFile.processingFormat
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(outputFile.length)))
+        try outputFile.read(into: buffer)
+
+        let samples = try XCTUnwrap(buffer.floatChannelData)[0]
+        var peak: Float = 0
+        for frame in 0..<Int(buffer.frameLength) {
+            peak = max(peak, abs(samples[frame]))
+        }
+        XCTAssertEqual(peak, 0.0, accuracy: 0.0001, "Equal-weight downmix of +0.5/-0.5 should be silence")
     }
 
     func testErrorHandling() async throws {
@@ -45,16 +108,12 @@ final class AudioConversionTests: XCTestCase {
     // MARK: - Bit Depth
 
     func test24BitOutput() async throws {
-        guard let inputURL = testBundle.url(forResource: "test_stereo", withExtension: "wav") else {
-            throw XCTSkip("Test fixture 'test_stereo.wav' not found in test bundle")
-        }
-
         let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_24bit.wav")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         var settings = OutputSettings()
         settings.bitDepth = .int24
-        try await convertAudioFile(inputURL: inputURL, outputURL: outputURL, settings: settings) { _ in }
+        try await convertAudioFile(inputURL: stereoFixtureURL, outputURL: outputURL, settings: settings) { _ in }
 
         let outputFile = try XCTUnwrap(try? AVAudioFile(forReading: outputURL))
         XCTAssertEqual(outputFile.processingFormat.channelCount, 1)
@@ -62,16 +121,12 @@ final class AudioConversionTests: XCTestCase {
     }
 
     func test32BitFloatOutput() async throws {
-        guard let inputURL = testBundle.url(forResource: "test_stereo", withExtension: "wav") else {
-            throw XCTSkip("Test fixture 'test_stereo.wav' not found in test bundle")
-        }
-
         let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_32float.wav")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         var settings = OutputSettings()
         settings.bitDepth = .float32
-        try await convertAudioFile(inputURL: inputURL, outputURL: outputURL, settings: settings) { _ in }
+        try await convertAudioFile(inputURL: stereoFixtureURL, outputURL: outputURL, settings: settings) { _ in }
 
         let outputFile = try XCTUnwrap(try? AVAudioFile(forReading: outputURL))
         XCTAssertEqual(outputFile.processingFormat.channelCount, 1)
@@ -81,16 +136,12 @@ final class AudioConversionTests: XCTestCase {
     // MARK: - AIFF Output
 
     func testAIFFOutput() async throws {
-        guard let inputURL = testBundle.url(forResource: "test_stereo", withExtension: "wav") else {
-            throw XCTSkip("Test fixture 'test_stereo.wav' not found in test bundle")
-        }
-
         let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_output.aiff")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         var settings = OutputSettings()
         settings.fileType = .aiff
-        try await convertAudioFile(inputURL: inputURL, outputURL: outputURL, settings: settings) { _ in }
+        try await convertAudioFile(inputURL: stereoFixtureURL, outputURL: outputURL, settings: settings) { _ in }
 
         let outputFile = try XCTUnwrap(try? AVAudioFile(forReading: outputURL))
         XCTAssertEqual(outputFile.processingFormat.channelCount, 1)
@@ -99,16 +150,12 @@ final class AudioConversionTests: XCTestCase {
     // MARK: - Sample Rate Conversion
 
     func testSampleRateConversion() async throws {
-        guard let inputURL = testBundle.url(forResource: "test_stereo", withExtension: "wav") else {
-            throw XCTSkip("Test fixture 'test_stereo.wav' not found in test bundle")
-        }
-
         let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_48k.wav")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         var settings = OutputSettings()
         settings.sampleRate = .resample(48000)
-        try await convertAudioFile(inputURL: inputURL, outputURL: outputURL, settings: settings) { _ in }
+        try await convertAudioFile(inputURL: stereoFixtureURL, outputURL: outputURL, settings: settings) { _ in }
 
         let outputFile = try XCTUnwrap(try? AVAudioFile(forReading: outputURL))
         XCTAssertEqual(outputFile.processingFormat.channelCount, 1)


### PR DESCRIPTION
Addresses findings from the code review.

## Changes
- **#35 — Test fixture.** Generate a stereo fixture programmatically in `setUp()` instead of `XCTSkip`-ing on a missing `test_stereo.wav`. All conversion tests now run, plus a new downmix-correctness test (L=+0.5 / R=−0.5 must sum to silence).
- **#37 — Dead update code.** Remove `GitHubRelease`, `compareVersions()`, and the `AppConstants` github* URLs (the app has no network entitlement).
- **#38 — Unused symbols.** Remove `removeFiles`, `clearFiles`, `addFile`, `formatFileSize`, `totalFileSize`, `selectOutputFolder`, `log` from `ContentView`.
- **#39 — Dead context menu.** Remove the unreachable `onRetry`/`onReveal` items in `FileRowView`.

## Verification
- `xcodebuild ... build` succeeds.
- Test bundle compiles + signs, but cannot load via CLI due to the pre-existing Team ID mismatch (#17). Full test run needs Xcode GUI or #17 resolved.

Closes #35, #37, #38, #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)