### PR TITLE
Parallelize batch conversion + float headroom fix

### DIFF
--- a/SampleDrumConverter/AudioConverter.swift
+++ b/SampleDrumConverter/AudioConverter.swift
@@ -96,12 +96,20 @@ private func downmixWeights(channelCount: Int) -> [Float] {
 
 // MARK: - Overwrite Protection
 
-/// Resolves the output URL to avoid overwriting existing files.
-/// Appends " (1)", " (2)", etc. before the extension until a unique path is found.
-func resolveOutputURL(_ proposedURL: URL) -> URL {
-    guard FileManager.default.fileExists(atPath: proposedURL.path) else {
-        return proposedURL
+/// Resolves an output URL that collides with neither an existing file on disk
+/// nor any path in `taken`. Appends " (1)", " (2)", etc. before the extension
+/// until a free path is found.
+///
+/// The `taken` set lets callers reserve names for conversions that haven't
+/// written their output yet — essential when files are converted in parallel,
+/// where two inputs sharing a base name would otherwise resolve to the same
+/// output path (a check-then-create race).
+func uniqueOutputURL(_ proposedURL: URL, taken: Set<String> = []) -> URL {
+    func isFree(_ url: URL) -> Bool {
+        !FileManager.default.fileExists(atPath: url.path) && !taken.contains(url.path)
     }
+
+    if isFree(proposedURL) { return proposedURL }
 
     let directory = proposedURL.deletingLastPathComponent()
     let ext = proposedURL.pathExtension
@@ -109,13 +117,17 @@ func resolveOutputURL(_ proposedURL: URL) -> URL {
 
     var counter = 1
     while true {
-        let newName = "\(baseName) (\(counter))"
-        let newURL = directory.appendingPathComponent(newName).appendingPathExtension(ext)
-        if !FileManager.default.fileExists(atPath: newURL.path) {
-            return newURL
-        }
+        let newURL = directory
+            .appendingPathComponent("\(baseName) (\(counter))")
+            .appendingPathExtension(ext)
+        if isFree(newURL) { return newURL }
         counter += 1
     }
+}
+
+/// Resolves the output URL to avoid overwriting existing files on disk.
+func resolveOutputURL(_ proposedURL: URL) -> URL {
+    uniqueOutputURL(proposedURL)
 }
 
 // MARK: - Audio Conversion
@@ -236,6 +248,10 @@ func convertAudioFile(
     // Get downmix weights for this channel layout
     let weights = downmixWeights(channelCount: intChannelCount)
 
+    // Clamping protects integer formats from wraparound on overflow. For
+    // 32-bit float output we keep the raw value to preserve headroom.
+    let clampToUnity = settings.bitDepth != .float32
+
     var currentFrame: Int64 = 0
 
     while currentFrame < fileLengthFrames {
@@ -265,8 +281,7 @@ func convertAudioFile(
             for channel in 0..<intChannelCount {
                 sample += floatBuffer[frame * intChannelCount + channel] * weights[channel]
             }
-            // Clamp to valid range
-            monoBuffer[frame] = max(-1.0, min(1.0, sample))
+            monoBuffer[frame] = clampToUnity ? max(-1.0, min(1.0, sample)) : sample
         }
 
         // Write mono float data — ExtAudioFile converts to target bit depth

--- a/SampleDrumConverter/ContentView.swift
+++ b/SampleDrumConverter/ContentView.swift
@@ -869,64 +869,81 @@ struct ConvertView: View {
         .padding()
     }
     
+    /// Max files converted at once. Conversion is largely disk/IO-bound, so a
+    /// small pool keeps cores busy without thrashing the disk.
+    private static let maxConcurrentConversions = 4
+
     private func startConversion() {
         guard let outputFolder = outputFolder else { return }
         isConverting = true
         isProcessing = true
-        
-        // Start conversion for first pending file
+
         Task {
-            await convertNextFile(outputFolder: outputFolder)
+            await convertAllFiles(outputFolder: outputFolder)
         }
     }
-    
-    private func convertNextFile(outputFolder: URL) async {
-        // Find first pending file
-        guard let index = audioFiles.firstIndex(where: { $0.status == .pending }) else {
-            await MainActor.run {
-                isConverting = false
-                isProcessing = false
-                currentStep = .completed
+
+    private func convertAllFiles(outputFolder: URL) async {
+        // Resolve every output path up front, sequentially, reserving each name.
+        // Doing this before any parallel work avoids a check-then-create race
+        // where two inputs sharing a base name pick the same output path.
+        let jobs: [(index: Int, input: URL, output: URL)] = await MainActor.run {
+            var taken = Set<String>()
+            var result: [(index: Int, input: URL, output: URL)] = []
+            for index in audioFiles.indices where audioFiles[index].status == .pending {
+                let input = audioFiles[index].url
+                let proposed = outputFolder
+                    .appendingPathComponent(input.deletingPathExtension().lastPathComponent + ".Mono")
+                    .appendingPathExtension(settings.fileType.fileExtension)
+                let output = uniqueOutputURL(proposed, taken: taken)
+                taken.insert(output.path)
+                result.append((index, input, output))
             }
-            return
+            return result
         }
-        
-        // Update file status
-        await MainActor.run {
-            audioFiles[index].status = .converting
-        }
-        
-        // Get input and output URLs
-        let inputURL = audioFiles[index].url
-        let proposedURL = outputFolder
-            .appendingPathComponent(inputURL.deletingPathExtension().lastPathComponent + ".Mono")
-            .appendingPathExtension(settings.fileType.fileExtension)
-        let outputURL = resolveOutputURL(proposedURL)
-        
-        do {
-            try await convertFile(at: index, from: inputURL, to: outputURL)
-            
-            await MainActor.run {
-                audioFiles[index].status = .completed
-                // Continue with next file
-                Task {
-                    await convertNextFile(outputFolder: outputFolder)
+
+        // Run conversions through a bounded task group: seed up to the limit,
+        // then start a new job each time one finishes.
+        await withTaskGroup(of: Void.self) { group in
+            var iterator = jobs.makeIterator()
+
+            func addNext() -> Bool {
+                guard let job = iterator.next() else { return false }
+                group.addTask {
+                    await self.convert(job: job)
                 }
+                return true
             }
+
+            for _ in 0..<Self.maxConcurrentConversions {
+                if !addNext() { break }
+            }
+            for await _ in group {
+                _ = addNext()
+            }
+        }
+
+        await MainActor.run {
+            isConverting = false
+            isProcessing = false
+            currentStep = .completed
+        }
+    }
+
+    private func convert(job: (index: Int, input: URL, output: URL)) async {
+        await MainActor.run { audioFiles[job.index].status = .converting }
+        do {
+            try await convertFile(at: job.index, from: job.input, to: job.output)
+            await MainActor.run { audioFiles[job.index].status = .completed }
         } catch {
             await MainActor.run {
-                audioFiles[index].status = .failed
-                audioFiles[index].errorMessage = error.localizedDescription
-                errorMessage = "Error converting \(inputURL.lastPathComponent): \(error.localizedDescription)"
-                
-                // Continue with next file despite error
-                Task {
-                    await convertNextFile(outputFolder: outputFolder)
-                }
+                audioFiles[job.index].status = .failed
+                audioFiles[job.index].errorMessage = error.localizedDescription
+                errorMessage = "Error converting \(job.input.lastPathComponent): \(error.localizedDescription)"
             }
         }
     }
-    
+
     private func convertFile(at index: Int, from inputURL: URL, to outputURL: URL) async throws {
         // Access security-scoped resource if needed (for sandboxed environments)
         // This handles URLs from drag-and-drop that may be security-scoped

--- a/SampleDrumConverterTests/AudioConversionTests.swift
+++ b/SampleDrumConverterTests/AudioConversionTests.swift
@@ -187,4 +187,18 @@ final class AudioConversionTests: XCTestCase {
         let resolved = resolveOutputURL(testFile)
         XCTAssertEqual(resolved.path, testFile.path)
     }
+
+    /// Guards the parallel-conversion race fix: two inputs sharing a base name
+    /// must not resolve to the same output path even before either is written.
+    func testUniqueOutputURLAvoidsReservedNames() {
+        let dir = FileManager.default.temporaryDirectory
+        let base = dir.appendingPathComponent("clash_\(UUID().uuidString).wav")
+
+        let first = uniqueOutputURL(base, taken: [])
+        let second = uniqueOutputURL(base, taken: [first.path])
+
+        XCTAssertEqual(first.path, base.path)
+        XCTAssertNotEqual(second.path, first.path)
+        XCTAssertTrue(second.lastPathComponent.contains("(1)"))
+    }
 }


### PR DESCRIPTION
## #42 — Parallel conversion
Replaces the one-file-at-a-time recursion in `ConvertView` with a **bounded `TaskGroup`** (max 4 concurrent). Conversion is disk/IO-bound, so a small pool keeps cores busy without thrashing.

**Race safety:** parallelizing exposed a check-then-create race in overwrite protection — two inputs sharing a base name (e.g. two `kick.wav` from different folders) would both resolve to `kick.Mono.wav`. Fixed by resolving **all** output paths sequentially up front, reserving each name via the new `uniqueOutputURL(_:taken:)` (existing `resolveOutputURL` now delegates to it). Added `testUniqueOutputURLAvoidsReservedNames`.

## #43 (app portion) — float headroom
Skip the `[-1, 1]` clamp for 32-bit float output (preserves headroom); integer formats still clamp to avoid wraparound distortion. The new downmix-correctness test exercises the float path.

## ⚠️ Needs runtime testing
Build + build-for-testing succeed, but the test bundle can't run via CLI (pre-existing #17 Team ID issue). Please verify in Xcode / a real run, especially:
- A large batch converts fully and the UI reaches the completion screen.
- Two input files with the **same filename** from different folders both produce distinct `*.Mono` / `*.Mono (1)` outputs.
- Drag-and-drop conversion still works.

## Note on #43 drag-drop item
On closer inspection the drag-drop security-scoped **bookmark logic is justified** (it turns transient drop access into a URL re-accessible at conversion time), so it was left intact rather than risk a sandbox regression. Only the float-clamp item of #43 is addressed here.

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)