### PR TITLE
chore: adopt IAMJARL project standards (CLAUDE.md + marketing template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/marketing_idea.yml
+++ b/.github/ISSUE_TEMPLATE/marketing_idea.yml
@@ -1,4 +1,3 @@
-# Copy to <repo>/.github/ISSUE_TEMPLATE/marketing_idea.yml and replace It's mono, yo! / JarlLyng/It-s-mono-yo-.
 # NOTE: this is for PUBLIC-SAFE marketing tasks only. Competitive-sensitive strategy
 # (positioning, pricing reasoning, channel edge, competitor analysis) goes in the PRIVATE
 # iamjarl-strategy hub instead — never in a public issue.

--- a/.github/ISSUE_TEMPLATE/marketing_idea.yml
+++ b/.github/ISSUE_TEMPLATE/marketing_idea.yml
@@ -1,0 +1,45 @@
+# Copy to <repo>/.github/ISSUE_TEMPLATE/marketing_idea.yml and replace It's mono, yo! / JarlLyng/It-s-mono-yo-.
+# NOTE: this is for PUBLIC-SAFE marketing tasks only. Competitive-sensitive strategy
+# (positioning, pricing reasoning, channel edge, competitor analysis) goes in the PRIVATE
+# iamjarl-strategy hub instead — never in a public issue.
+name: Marketing idea / task
+description: A public-safe marketing idea or task (content, post, screenshot, outreach).
+title: '[Marketing] '
+labels: ['marketing']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For **public-safe** marketing work only — a blog post, a community thread, a screenshot to redo, an ASO copy tweak.
+        **Anything competitive-sensitive** (positioning, pricing reasoning, channel plans that reveal an edge, competitor analysis) does **not** belong in a public issue — put it in the private [iamjarl-strategy](https://github.com/JarlLyng/iamjarl-strategy) hub instead.
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea / task
+      description: What's the marketing move, and what's the goal?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Channel
+      options:
+        - App Store / ASO
+        - SEO / content
+        - Reddit / community
+        - Social
+        - Newsletter / outreach
+        - Website / landing page
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public-safe check
+      options:
+        - label: This contains nothing a competitor reading it could use against us (else it goes in the private strategy hub)
+          required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md — It's mono, yo!
+
+Quick-start context for developers and AI assistants.
+
+## What is It's mono, yo!?
+
+An open-source macOS app for **batch converting stereo WAV and AIFF audio to mono**, with configurable bit depth, sample rate, and output format. Built for hardware samplers (Erica Synths Sample Drum, Elektron Digitakt, Roland SP-404, Eurorack). Native, lightweight, no internet required.
+
+- **Developer:** Jarl Lyng / [IAMJARL](https://iamjarl.com)
+- **Website:** [itsmonoyo.iamjarl.com](https://itsmonoyo.iamjarl.com)
+- **App Store:** [apps.apple.com/app/its-mono-yo/id6758866918](https://apps.apple.com/app/its-mono-yo/id6758866918?mt=12)
+- **License:** [MIT](LICENSE) — open source.
+- **Price:** $0.99 USD one-time (no in-app purchases, no subscription, no ads)
+- **Platform:** macOS 11.0+ (SwiftUI).
+
+## Strategy lives in the private hub
+
+Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competitor analysis are **not** in this public repo — they're in the private [iamjarl-strategy](https://github.com/JarlLyng/iamjarl-strategy) hub (folder `ItsMonoYo/`). Before doing any audience/positioning/pricing/marketing-planning work, read that repo's `CONVENTIONS.md` and write results there, not here.
+
+## App features (be precise — do not invent features that don't exist)
+
+- **Batch conversion** — drag in unlimited WAV/AIFF files; **folder import** preserves structure recursively.
+- **Configurable bit depth** — 16-bit (default), 24-bit, or 32-bit float; **output** WAV or AIFF.
+- **Sample rate** — keep original or convert to 44.1 / 48 / 96 kHz.
+- **Intelligent downmix** — proper stereo summing; multi-channel uses ITU-R BS.775 weighted coefficients.
+- **Overwrite protection** — existing files auto-renamed, never replaced.
+- Drag & drop; keyboard shortcuts (⌘O open, ESC back); VoiceOver / Reduce Motion / dark mode.
+- In-app App Store review prompt after repeated successful conversions.
+
+### Features that do NOT exist (common hallucination targets)
+- No internet / cloud / accounts.
+- No file count or size limits, but no audio *editing* — it converts, it doesn't edit.
+- No subscription / IAP.
+
+## Build & conventions
+- SwiftUI, step-based conversion flow; Swift async/await with a bounded task group for parallel per-file conversion.
+- Sandboxed App Store build with accessibility support.
+- Privacy-first: no internet required; no tracking.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competit
 - **Sample rate** — keep original or convert to 44.1 / 48 / 96 kHz.
 - **Intelligent downmix** — proper stereo summing; multi-channel uses ITU-R BS.775 weighted coefficients.
 - **Overwrite protection** — existing files auto-renamed, never replaced.
-- Drag & drop; keyboard shortcuts (⌘O open, ESC back); VoiceOver / Reduce Motion / dark mode.
+- Drag & drop; keyboard shortcut (⌘O to open files); VoiceOver / Reduce Motion / dark mode.
 - In-app App Store review prompt after repeated successful conversions.
 
 ### Features that do NOT exist (common hallucination targets)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **Multi-channel support** — weighted downmix using ITU-R BS.775 coefficients for surround audio
 - **Overwrite protection** — existing files are auto-renamed, never replaced
 - **Drag and drop** — drop files directly into the app
-- **Keyboard shortcuts** — ⌘O to open, ESC to go back
+- **Keyboard shortcut** — ⌘O to open files
 - **Accessibility** — VoiceOver support, Reduce Motion, system dark mode
 - **Native macOS** — built with SwiftUI, lightweight, no internet required
 


### PR DESCRIPTION
Adopts the shared IAMJARL project standards (defined in the private `iamjarl-strategy` hub).

**Adds:**
- `CLAUDE.md` — AI/dev context (precise feature list incl. a "features that do NOT exist" section; points strategy work at the private hub).
- `.github/ISSUE_TEMPLATE/marketing_idea.yml` — public-safe marketing-idea form (this repo already had bug/feature templates).

Please review feature accuracy in `CLAUDE.md` before merging.
