### PR TITLE
chore: add CHANGELOG + SECURITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to It's mono, yo! are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/); this log starts at the
+current release — earlier versions predate it.
+
+## [1.4.0] - 2026-06
+
+Current released version. Detailed per-version history is tracked from here.
+
+<!-- Add entries under new version headings going forward, e.g.:
+## [1.5.0] - YYYY-MM-DD
+### Added
+- …
+### Fixed
+- …
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,51 @@
 # Changelog
 
 All notable changes to It's mono, yo! are documented here.
-Format follows [Keep a Changelog](https://keepachangelog.com/); this log starts at the
-current release — earlier versions predate it.
+Format follows [Keep a Changelog](https://keepachangelog.com/).
+
+> Entries are reconstructed from release notes. Releases up to 1.3.0 predate this
+> changelog, and exact release dates for the earliest versions were not recorded.
 
 ## [1.4.0] - 2026-06
-
-Current released version. Detailed per-version history is tracked from here.
-
-<!-- Add entries under new version headings going forward, e.g.:
-## [1.5.0] - YYYY-MM-DD
 ### Added
-- …
-### Fixed
-- …
--->
+- Folder import: drop or select a folder and convert an entire sample pack in one go, preserving the source folder structure in the output.
+
+## [1.3.1] - 2026-06
+### Added
+- Conversion test suite now runs against a generated audio fixture.
+### Changed
+- Batches convert in parallel via a bounded task group (faster on large batches).
+- 32-bit float output preserves full headroom (no unnecessary clamping).
+### Removed
+- Unused internal code paths.
+
+## [1.3.0] - 2026-03
+### Added
+- In-app App Store review prompt after repeated successful conversions.
+### Changed
+- Updated to IAMJARL Design System v0.5.0.
+
+## [1.2.0]
+### Added
+- Configurable output bit depth (16-bit, 24-bit, 32-bit float).
+- AIFF input and output support.
+- Sample rate conversion (44.1 / 48 / 96 kHz).
+- Weighted multi-channel downmix (ITU-R BS.775).
+- Overwrite protection with auto-rename.
+- Reduce Motion accessibility support.
+### Changed
+- Removed file count and size limits.
+- Refactored into AudioConverter, OutputSettings, and ReducedMotion modules.
+
+## [1.0.8]
+### Added
+- App Store release with sandbox and accessibility support (VoiceOver, dark mode, accessibility URL).
+- Export compliance declaration.
+
+## [1.0.7]
+### Changed
+- Improved mono conversion quality.
+- Async/await conversion pipeline.
+- Semantic versioning fix.
+### Removed
+- AudioKit dependency.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you've found a security issue in It's mono, yo!, please **don't open a public issue**. Email me directly:
+
+**jarl@iamjarl.com**
+
+Please include:
+- A description of the vulnerability
+- Steps to reproduce
+- The affected version (Mac App Store version or commit SHA)
+- Your contact info if you'd like credit when it's fixed
+
+I'll respond within 7 days. For confirmed issues, I'll work on a patch and ship it as quickly as the App Store review process allows (typically 1–3 days for review, plus development time).
+
+## Scope
+
+In scope:
+- It's mono, yo! macOS app code
+- The marketing site at `itsmonoyo.iamjarl.com`
+
+Out of scope:
+- Apple platform vulnerabilities — report to Apple Product Security
+- Issues in forks of this repo
+
+## What It's mono, yo! does and doesn't handle
+
+It's mono, yo! is a single-purpose audio batch converter with a deliberately small attack surface:
+
+- **No backend.** No server, no database, no API endpoints.
+- **No accounts.** No sign-up, no authentication, no password storage.
+- **No internet.** The app does not require or use a network connection; audio files are converted entirely on-device.
+- **No tracking.** No analytics in the app. The marketing website uses aggregate, cookieless analytics only.
+- **Local file access only.** The app reads the audio files/folders you drop in and writes converted output (auto-renaming to avoid overwriting). Runs in the App Store sandbox.
+
+If you find a way to break any of those guarantees, I want to know.
+
+## Past advisories
+
+None to date.


### PR DESCRIPTION
Closes the remaining doc gaps from the IAMJARL project-standards rollout.

**Adds:**
- `CHANGELOG.md` — Keep-a-Changelog scaffold anchored at the current release (1.4.0); per-version history tracked from here.
- `SECURITY.md` — private vulnerability-reporting policy + scope (matches the rest of the portfolio).
