### PR TITLE
Adopt shared iamjarl-design tokens via SPM (#53)

### DIFF
--- a/It's mono, yo!.xcodeproj/project.pbxproj
+++ b/It's mono, yo!.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		D511C0DE0000000000000003 /* IAMJARLDesignTokens in Frameworks */ = {isa = PBXBuildFile; productRef = D511C0DE0000000000000002 /* IAMJARLDesignTokens */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		3B469F292D1E18C4004E5EDE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -52,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D511C0DE0000000000000003 /* IAMJARLDesignTokens in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -104,6 +109,7 @@
 			);
 			name = "It's mono, yo!";
 			packageProductDependencies = (
+				D511C0DE0000000000000002 /* IAMJARLDesignTokens */,
 			);
 			productName = SampleDrumConverter;
 			productReference = 3BDF76072D1F625D00189ABE /* It's mono, yo!.app */;
@@ -188,6 +194,7 @@
 			mainGroup = 3B469F0E2D1E18C2004E5EDE;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				D511C0DE0000000000000001 /* XCRemoteSwiftPackageReference "iamjarl-design" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 3B469F0E2D1E18C2004E5EDE;
@@ -567,6 +574,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D511C0DE0000000000000001 /* XCRemoteSwiftPackageReference "iamjarl-design" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/JarlLyng/iamjarl-design.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D511C0DE0000000000000002 /* IAMJARLDesignTokens */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D511C0DE0000000000000001 /* XCRemoteSwiftPackageReference "iamjarl-design" */;
+			productName = IAMJARLDesignTokens;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3B469F0F2D1E18C2004E5EDE /* Project object */;
 }

--- a/It's mono, yo!.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/It's mono, yo!.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "98ea44209d0bb2401f8d5991fdbb1a40437eadd90693705e08fc89c2b73485d0",
+  "pins" : [
+    {
+      "identity" : "iamjarl-design",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JarlLyng/iamjarl-design.git",
+      "state" : {
+        "revision" : "5c5ccacaa88ee97571ca7dc49d55cf317a09e77e",
+        "version" : "1.1.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SampleDrumConverter/ContentView.swift
+++ b/SampleDrumConverter/ContentView.swift
@@ -592,7 +592,7 @@ struct SelectFilesView: View {
                                 .fontWeight(.medium)
                             
                             ScrollView {
-                                VStack(alignment: .leading, spacing: 8) {
+                                VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                                     ForEach(audioFiles) { file in
                                         FileRowView(file: file, onRemove: {
                                             // Handle file removal here
@@ -602,7 +602,7 @@ struct SelectFilesView: View {
                                         })
                                     }
                                 }
-                                .padding(.vertical, 4)
+                                .padding(.vertical, DesignTokens.Spacing.xs)
                             }
                             .frame(maxHeight: geometry.size.height * 0.4)  // Relative height
                         }
@@ -715,14 +715,14 @@ struct SelectOutputView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
+            VStack(spacing: DesignTokens.Spacing.xxl) {
                 // Title
                 Text("Output Settings")
                     .font(.title)
                     .fontWeight(.bold)
 
                 // Folder select area
-                VStack(spacing: 16) {
+                VStack(spacing: DesignTokens.Spacing.lg) {
                     Image(systemName: "folder.fill")
                         .font(.system(size: 36, weight: .ultraLight))
 
@@ -794,7 +794,7 @@ struct SelectOutputView: View {
                 .cornerRadius(DesignTokens.Radius.md)
 
                 // Navigation buttons
-                HStack(spacing: 20) {
+                HStack(spacing: DesignTokens.Spacing.xl) {
                     Button(action: onBack) {
                         Text("Back")
                             .fontWeight(.medium)
@@ -850,13 +850,13 @@ struct ConvertView: View {
                 .fontWeight(.bold)
             
             // Status and progress
-            VStack(spacing: 20) {
+            VStack(spacing: DesignTokens.Spacing.xl) {
                 Image(systemName: "waveform.circle.fill")
                     .font(.system(size: 40, weight: .ultraLight))
                 
                 if isConverting {
                     let completed = audioFiles.filter { $0.status == .completed }.count
-                    VStack(spacing: 8) {
+                    VStack(spacing: DesignTokens.Spacing.sm) {
                         Text("Converting files...")
                             .fontWeight(.medium)
                         Text("\(completed) of \(audioFiles.count) completed")
@@ -904,7 +904,7 @@ struct ConvertView: View {
                 .buttonStyle(.bordered)
                 .disabled(outputFolder == nil)
             } else {
-                HStack(spacing: 20) {
+                HStack(spacing: DesignTokens.Spacing.xl) {
                     Button(action: onBack) {
                         Text("Back")
                             .fontWeight(.medium)

--- a/SampleDrumConverter/DesignTokens.swift
+++ b/SampleDrumConverter/DesignTokens.swift
@@ -2,256 +2,49 @@
 //  DesignTokens.swift
 //  It's mono, yo!
 //
-//  IAMJARL Design System Tokens (v0.5.0)
-//  Source: https://github.com/JarlLyng/iamjarl-design
+//  Re-exports the shared IAMJARL design tokens (SPM package) and adds the
+//  app-specific, scheme-aware accessors the views use. Replaces the former
+//  local token copy so there is a single source of truth across the portfolio.
+//  Package: https://github.com/JarlLyng/iamjarl-design
 //
 
 import SwiftUI
+@_exported import IAMJARLDesignTokens
 
-// MARK: - Design Tokens
-
-struct DesignTokens {
-    // MARK: - Spacing
-    struct Spacing {
-        static let xs: CGFloat = 4
-        static let sm: CGFloat = 8
-        static let md: CGFloat = 12
-        static let lg: CGFloat = 16
-        static let xl: CGFloat = 20
-        static let xxl: CGFloat = 24
-        static let xxxl: CGFloat = 32
-    }
-    
-    // MARK: - Radius
-    struct Radius {
-        static let sm: CGFloat = 8
-        static let md: CGFloat = 12
-        static let lg: CGFloat = 16
-    }
-
-    // MARK: - Motion
-    struct Motion {
-        struct Duration {
-            static let fast: Double = 0.150
-            static let normal: Double = 0.250
-            static let slow: Double = 0.400
-        }
-    }
-
-    // MARK: - Shadows
-    struct Shadow {
-        // Use as .shadow(color:radius:x:y:) in SwiftUI
-        struct Small {
-            static let color = Color.black.opacity(0.05)
-            static let radius: CGFloat = 1
-            static let y: CGFloat = 1
-        }
-        struct Medium {
-            static let color = Color.black.opacity(0.08)
-            static let radius: CGFloat = 4
-            static let y: CGFloat = 4
-        }
-        struct Large {
-            static let color = Color.black.opacity(0.12)
-            static let radius: CGFloat = 12
-            static let y: CGFloat = 8
-        }
-    }
-    
-    // MARK: - Typography
-    struct Typography {
-        struct Size {
-            static let xs: CGFloat = 12
-            static let sm: CGFloat = 14
-            static let base: CGFloat = 16
-            static let lg: CGFloat = 18
-            static let xl: CGFloat = 24
-            static let xxl: CGFloat = 36
-        }
-        
-        struct Weight {
-            static let regular: Font.Weight = .regular
-            static let semibold: Font.Weight = .semibold
-            static let bold: Font.Weight = .bold
-        }
-        
-        struct LineHeight {
-            static let tight: CGFloat = 20
-            static let normal: CGFloat = 24
-            static let relaxed: CGFloat = 28
-            static let sm: CGFloat = 18
-            static let xxl: CGFloat = 43.2
-        }
-    }
-    
-    // MARK: - Colors
-    struct Colors {
-        // Static colors
-        struct Static {
-            static let black = Color(hex: "000000")
-            static let white = Color(hex: "FFFFFF")
-        }
-        
-        // Shared state colors
-        struct Shared {
-            static let success = Color(hex: "4CAF50")
-            static let onSuccess = Color(hex: "000000")
-            static let warning = Color(hex: "FF6B35")
-            static let onWarning = Color(hex: "000000")
-            static let error = Color(hex: "D70015")
-            static let onError = Color(hex: "FFFFFF")
-        }
-
-        // Mode-specific colors
-        struct Light {
-            static let primary = Color(hex: "A435D2")
-            static let onPrimary = Color(hex: "FFFFFF")
-            
-            struct Text {
-                static let primary = Color(hex: "000000")
-                static let secondary = Color(hex: "000000").opacity(0.70)
-                static let tertiary = Color(hex: "000000").opacity(0.55)
-                static let inverse = Color(hex: "FFFFFF")
-            }
-            
-            struct Background {
-                static let app = Color(hex: "FFFFFF")
-                static let muted = Color(hex: "000000").opacity(0.04)
-                static let card = Color(hex: "000000").opacity(0.04)
-            }
-            
-            struct Surface {
-                static let `default` = Color(hex: "FFFFFF")
-                static let raised = Color(hex: "000000").opacity(0.02)
-            }
-            
-            struct Border {
-                static let subtle = Color(hex: "000000").opacity(0.10)
-                static let `default` = Color(hex: "000000").opacity(0.16)
-            }
-        }
-        
-        struct Dark {
-            static let primary = Color(hex: "D0FF00")
-            static let onPrimary = Color(hex: "000000")
-            
-            struct Text {
-                static let primary = Color(hex: "FFFFFF")
-                static let secondary = Color(hex: "FFFFFF").opacity(0.75)
-                static let tertiary = Color(hex: "FFFFFF").opacity(0.60)
-                static let inverse = Color(hex: "000000")
-            }
-            
-            struct Background {
-                static let app = Color(hex: "000000")
-                static let muted = Color(hex: "FFFFFF").opacity(0.05)
-                static let card = Color(hex: "FFFFFF").opacity(0.05)
-            }
-            
-            struct Surface {
-                static let `default` = Color(hex: "000000")
-                static let raised = Color(hex: "FFFFFF").opacity(0.03)
-            }
-            
-            struct Border {
-                static let subtle = Color(hex: "FFFFFF").opacity(0.12)
-                static let `default` = Color(hex: "FFFFFF").opacity(0.18)
-            }
-        }
-    }
-}
-
-// MARK: - Environment-aware color helpers
+// MARK: - App-specific convenience
 
 extension ColorScheme {
-    var isDark: Bool {
-        self == .dark
-    }
+    var isDark: Bool { self == .dark }
 }
 
-// Removed adaptiveColor extension - use AdaptiveColor helper functions instead
-
-// MARK: - Color Scheme Helper
-
-struct AdaptiveColor {
-    static func primary(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.primary : DesignTokens.Colors.Light.primary
-    }
-
-    static func onPrimary(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.onPrimary : DesignTokens.Colors.Light.onPrimary
-    }
-    
-    static func textPrimary(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Text.primary : DesignTokens.Colors.Light.Text.primary
-    }
-    
-    static func textSecondary(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Text.secondary : DesignTokens.Colors.Light.Text.secondary
-    }
-    
-    static func textTertiary(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Text.tertiary : DesignTokens.Colors.Light.Text.tertiary
-    }
-    
-    static func textInverse(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Text.inverse : DesignTokens.Colors.Light.Text.inverse
-    }
-    
-    static func backgroundApp(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Background.app : DesignTokens.Colors.Light.Background.app
-    }
-    
-    static func backgroundMuted(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Background.muted : DesignTokens.Colors.Light.Background.muted
-    }
-    
-    static func backgroundCard(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Background.card : DesignTokens.Colors.Light.Background.card
-    }
-    
-    static func surfaceDefault(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Surface.default : DesignTokens.Colors.Light.Surface.default
-    }
-    
-    static func surfaceRaised(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Surface.raised : DesignTokens.Colors.Light.Surface.raised
-    }
-    
-    static func borderSubtle(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Border.subtle : DesignTokens.Colors.Light.Border.subtle
-    }
-    
-    static func borderDefault(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? DesignTokens.Colors.Dark.Border.default : DesignTokens.Colors.Light.Border.default
-    }
-}
-
-// MARK: - Color Extension for Hex Support
-
-extension Color {
-    init(hex: String) {
-        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        var int: UInt64 = 0
-        Scanner(string: hex).scanHexInt64(&int)
-        let a, r, g, b: UInt64
-        switch hex.count {
-        case 3: // RGB (12-bit)
-            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-        case 6: // RGB (24-bit)
-            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8: // ARGB (32-bit)
-            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
-        default:
-            (a, r, g, b) = (1, 1, 1, 0)
+// The views reference `DesignTokens.Colors.Shared.*`; the package exposes the
+// same flat state colors under `ColorToken.State`. Bridge them so the existing
+// call sites compile unchanged (identical values).
+extension DesignTokens {
+    enum Colors {
+        enum Shared {
+            static let success = DesignTokens.ColorToken.State.success
+            static let onSuccess = DesignTokens.ColorToken.State.onSuccess
+            static let warning = DesignTokens.ColorToken.State.warning
+            static let onWarning = DesignTokens.ColorToken.State.onWarning
+            static let error = DesignTokens.ColorToken.State.error
+            static let onError = DesignTokens.ColorToken.State.onError
         }
-
-        self.init(
-            .sRGB,
-            red: Double(r) / 255,
-            green: Double(g) / 255,
-            blue:  Double(b) / 255,
-            opacity: Double(a) / 255
-        )
     }
+}
+
+// MARK: - Scheme-aware color accessors (backed by the shared package)
+
+enum AdaptiveColor {
+    static func primary(_ s: ColorScheme) -> Color { DesignTokens.Common.primary(s) }
+    static func onPrimary(_ s: ColorScheme) -> Color { DesignTokens.Common.OnPrimary.text(s) }
+    static func textPrimary(_ s: ColorScheme) -> Color { DesignTokens.Common.Text.primary(s) }
+    static func textSecondary(_ s: ColorScheme) -> Color { DesignTokens.Common.Text.secondary(s) }
+    static func textTertiary(_ s: ColorScheme) -> Color { DesignTokens.Common.Text.tertiary(s) }
+    static func textInverse(_ s: ColorScheme) -> Color { DesignTokens.Common.Text.inverse(s) }
+    static func backgroundApp(_ s: ColorScheme) -> Color { DesignTokens.Common.Background.app(s) }
+    static func backgroundMuted(_ s: ColorScheme) -> Color { DesignTokens.Common.Background.muted(s) }
+    static func backgroundCard(_ s: ColorScheme) -> Color { DesignTokens.Common.Background.card(s) }
+    static func borderSubtle(_ s: ColorScheme) -> Color { DesignTokens.Common.Border.subtle(s) }
+    static func borderDefault(_ s: ColorScheme) -> Color { DesignTokens.Common.Border.`default`(s) }
 }


### PR DESCRIPTION
Adopts the shared `IAMJARLDesignTokens` SPM package so the app stops keeping a local copy of the design tokens (portfolio single-source-of-truth).

## Prerequisite (separate repo, already done)
`iamjarl-design` required macOS 13 but this app targets macOS 11. Rather than drop macOS 11/12 users for an internal refactor, I lowered the package's platform floor to macOS 11 (the token API is plain SwiftUI, no 13-only calls) and released **v1.1.0**. Non-breaking for existing consumers (WODrounds on macOS 13 unaffected).

## This PR
- **SPM dependency**: adds `iamjarl-design` 1.1.0 (`IAMJARLDesignTokens`) to the app target; `Package.resolved` committed.
- **DesignTokens.swift**: replaced the local token copy with `@_exported import IAMJARLDesignTokens` + a thin shim — `AdaptiveColor.*` now delegates to `DesignTokens.Common.*`, and a `DesignTokens.Colors.Shared` bridge maps to the package's `ColorToken.State`. **All ~50 view call sites are unchanged and the values are byte-identical, so zero visual change.**
- **Literal cleanup**: spacing literals that match the token scale (8/16/20/24/4) now use `DesignTokens.Spacing.*`. A handful of off-scale one-offs (2/10/15/30) are intentionally left — tokenizing them would shift layout or require inventing app-specific tokens.

## Verification
- `build` succeeds; full `xcodebuild test` suite passes (incl. the conversion/folder-import/stress tests).
- SPM resolves `IAMJARLDesignTokens @ 1.1.0`.
- Deployment target stays macOS 11.0 (no users dropped).

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)